### PR TITLE
Decouple sprotty-Theia integration from LSP

### DIFF
--- a/src/sprotty/languageserver/code-action-palette.ts
+++ b/src/sprotty/languageserver/code-action-palette.ts
@@ -17,7 +17,7 @@
 import { inject, injectable } from "inversify";
 import { Action, EMPTY_ROOT, HtmlRootSchema, PopupHoverMouseListener, RequestPopupModelAction,
     SButton, SButtonSchema, SetPopupModelAction, SModelElement, SModelElementSchema, SModelRootSchema } from "sprotty/lib";
-import { TheiaDiagramServerProvider, IRootPopupModelProvider } from '../theia-diagram-server';
+import { LSTheiaDiagramServerProvider, IRootPopupModelProvider } from '../theia-diagram-server';
 import { CodeAction, CodeActionParams, CodeActionRequest, Range } from '@theia/languages/lib/browser';
 import { WorkspaceEditAction } from "./workspace-edit-command";
 import { getRange } from "./traceable";
@@ -25,7 +25,7 @@ import { getRange } from "./traceable";
 @injectable()
 export class CodeActionProvider {
 
-    @inject(TheiaDiagramServerProvider) diagramServerProvider: TheiaDiagramServerProvider;
+    @inject(LSTheiaDiagramServerProvider) diagramServerProvider: LSTheiaDiagramServerProvider;
 
     async getCodeActions(range: Range, codeActionKind: string) {
         const diagramServer = await this.diagramServerProvider();
@@ -95,7 +95,7 @@ export class PaletteButton extends SButton {
 export class PaletteMouseListener extends PopupHoverMouseListener {
 
     @inject(CodeActionProvider) codeActionProvider: CodeActionProvider;
-    @inject(TheiaDiagramServerProvider) diagramServerProvider: TheiaDiagramServerProvider;
+    @inject(LSTheiaDiagramServerProvider) diagramServerProvider: LSTheiaDiagramServerProvider;
 
     mouseDown(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
         if (target instanceof PaletteButton) {

--- a/src/sprotty/languageserver/completion-label-edit.ts
+++ b/src/sprotty/languageserver/completion-label-edit.ts
@@ -16,14 +16,14 @@
 
 import { SLabel } from "sprotty/lib";
 import { inject, injectable } from "inversify";
-import { TheiaDiagramServerProvider } from "../theia-diagram-server";
+import { LSTheiaDiagramServerProvider } from "../theia-diagram-server";
 import { CompletionRequest, CompletionList, CompletionItem, TextEdit } from '@theia/languages/lib/browser';
 import { Traceable, getRange } from "./traceable";
 
 @injectable()
 export class CompletionLabelEditor {
 
-    @inject(TheiaDiagramServerProvider) diagramServerProvider: TheiaDiagramServerProvider;
+    @inject(LSTheiaDiagramServerProvider) diagramServerProvider: LSTheiaDiagramServerProvider;
 
     async edit(element: SLabel & Traceable) {
         const range = getRange(element);

--- a/src/sprotty/languageserver/rename-label-edit.ts
+++ b/src/sprotty/languageserver/rename-label-edit.ts
@@ -18,13 +18,13 @@ import { RenameRequest } from '@theia/languages/lib/browser';
 import { SingleTextInputDialog } from '@theia/core/lib/browser';
 import { inject, injectable } from "inversify";
 import { SLabel } from "sprotty/lib";
-import { TheiaDiagramServerProvider } from "../theia-diagram-server";
+import { LSTheiaDiagramServerProvider } from "../theia-diagram-server";
 import { Traceable, getRange } from './traceable';
 
 @injectable()
 export class RenameLabelEditor {
 
-    @inject(TheiaDiagramServerProvider) diagramServerProvider: TheiaDiagramServerProvider;
+    @inject(LSTheiaDiagramServerProvider) diagramServerProvider: LSTheiaDiagramServerProvider;
 
     async edit(element: SLabel & Traceable) {
         const range = getRange(element);

--- a/src/sprotty/languageserver/workspace-edit-command.ts
+++ b/src/sprotty/languageserver/workspace-edit-command.ts
@@ -14,15 +14,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Action, Command, CommandExecutionContext, CommandResult, TYPES } from "sprotty/lib";
 import { Workspace, WorkspaceEdit } from "@theia/languages/lib/browser";
 import { inject, injectable } from "inversify";
-import { TheiaDiagramServer } from "../theia-diagram-server";
+import { Action, Command, CommandExecutionContext, CommandResult, TYPES } from "sprotty/lib";
+import { LSTheiaDiagramServer } from "../theia-diagram-server";
 
 @injectable()
 export abstract class AbstractWorkspaceEditCommand extends Command {
 
-    @inject(TheiaDiagramServer) diagramServer: TheiaDiagramServer;
+    @inject(LSTheiaDiagramServer) diagramServer: LSTheiaDiagramServer;
 
     abstract createWorkspaceEdit(context: CommandExecutionContext): WorkspaceEdit
 

--- a/src/sprotty/theia-sprotty-connector.ts
+++ b/src/sprotty/theia-sprotty-connector.ts
@@ -37,6 +37,22 @@ export interface TheiaSprottyConnectorServices {
 /**
  * Connects sprotty DiagramServers to a Theia LanguageClientContribution.
  *
+ * Instances bridge the gap between the sprotty DI containers (one per
+ * diagram) and a specific connection client (e.g. LSP client) from the Theia DI container
+ * (one per application).
+ */
+export interface TheiaSprottyConnector {
+    connect(diagramServer: TheiaDiagramServer): void
+    disconnect(diagramServer: TheiaDiagramServer): void
+    save(uri: string, action: ExportSvgAction): void
+    showStatus(widgetId: string, status: ServerStatusAction): void
+    sendMessage(message: ActionMessage): void
+    onMessageReceived(message: ActionMessage): void
+}
+
+/**
+ * Connects sprotty DiagramServers to a Theia LanguageClientContribution.
+ *
  * Used to tunnel sprotty actions to and from the sprotty server through
  * the LSP.
  *
@@ -44,8 +60,7 @@ export interface TheiaSprottyConnectorServices {
  * diagram) and a specific language client from the Theia DI container
  * (one per application).
  */
-export class TheiaSprottyConnector implements TheiaSprottyConnectorServices, ActionMessageReceiver {
-
+export class LSTheiaSprottyConnector implements TheiaSprottyConnector, TheiaSprottyConnectorServices, ActionMessageReceiver {
     private servers: TheiaDiagramServer[] = []
 
     readonly diagramLanguageClient: DiagramLanguageClient
@@ -84,7 +99,7 @@ export class TheiaSprottyConnector implements TheiaSprottyConnectorServices, Act
             widget.setStatus(status)
     }
 
-    sendThroughLsp(message: ActionMessage) {
+    sendMessage(message: ActionMessage) {
         this.diagramLanguageClient.sendThroughLsp(message)
     }
 
@@ -92,7 +107,7 @@ export class TheiaSprottyConnector implements TheiaSprottyConnectorServices, Act
         return this.diagramLanguageClient.languageClient
     }
 
-    receivedThroughLsp(message: ActionMessage): void {
+    onMessageReceived(message: ActionMessage): void {
         this.servers.forEach(element => {
             element.messageReceived(message)
         })

--- a/src/theia/languageserver/diagram-language-client.ts
+++ b/src/theia/languageserver/diagram-language-client.ts
@@ -23,7 +23,7 @@ import { ActionMessage } from 'sprotty/lib';
 import { DiagramWidget } from '../diagram-widget';
 
 export interface ActionMessageReceiver {
-    receivedThroughLsp(message: ActionMessage): void
+    onMessageReceived(message: ActionMessage): void
 }
 
 export interface OpenInTextEditorMessage {
@@ -46,7 +46,7 @@ export class DiagramLanguageClient {
                 readonly editorManager: EditorManager) {
         this.languageClientContribution.languageClient.then(
             lc => {
-                lc.onNotification(acceptMessageType, this.receivedThroughLsp.bind(this))
+                lc.onNotification(acceptMessageType, this.onMessageReceived.bind(this))
                 lc.onNotification(openInTextEditorMessageType, this.openInTextEditor.bind(this))
             }
         ).catch(
@@ -92,9 +92,9 @@ export class DiagramLanguageClient {
         );
     }
 
-    receivedThroughLsp(message: ActionMessage) {
+    onMessageReceived(message: ActionMessage) {
         this.actionMessageReceivers.forEach(client => {
-            client.receivedThroughLsp(message)
+            client.onMessageReceived(message)
         })
     }
 

--- a/src/theia/languageserver/languageserver-diagram-contributions.ts
+++ b/src/theia/languageserver/languageserver-diagram-contributions.ts
@@ -21,6 +21,7 @@ import { DeleteWithWorkspaceEditAction } from "../../sprotty/languageserver/dele
 import { DiagramCommandHandler, DiagramCommands } from "../diagram-commands";
 import { DiagramKeybindingContext } from "../diagram-keybinding";
 import { DiagramWidget } from "../diagram-widget";
+import { LSTheiaSprottyConnector } from "../../sprotty/theia-sprotty-connector";
 
 @injectable()
 export class LSDiagramCommandContribution implements CommandContribution {
@@ -37,7 +38,7 @@ export class LSDiagramCommandContribution implements CommandContribution {
             DiagramCommands.DELETE,
             new DiagramCommandHandler(this.shell, widget => {
                 if (widget instanceof DiagramWidget) {
-                    const workspace  = widget.connector ? widget.connector.workspace : undefined;
+                    const workspace = widget.connector instanceof LSTheiaSprottyConnector ? widget.connector.workspace : undefined;
                     if (workspace) {
                         const action = new DeleteWithWorkspaceEditAction(workspace, widget.uri.toString(true));
                         widget.actionDispatcher.dispatch(action);


### PR DESCRIPTION
Currently the glue code for using sprotty diagrams in Theia is tightly coupled to the language server protocol. It's not possible to use this integration code with non LSP-based sprotty servers  without major modifications. 

This change is a proposal to loose the coupling of the sprotty-theia integration and LSP by:
+ Extracting a generic TheiaSprottyConnector Interface and refactor the existing implementation to  LSTheiaSprottyConnector
+ Extracting a generic abstract TheiaDiagramServer and refactor the existing implementation to LSTheiaDiagramServer  

With this changes the glue code can be reused for all types of sprotty servers and communication protocols by implementing customized TheiaSprottyConnector and TheiaDiagramServer classes.

In particular this would enable the GLSP project to reuse this glue code without maintaining a fork.