### PR TITLE
[theia-sprotty-connector] Remove diagram server on disconnect

### DIFF
--- a/src/sprotty/languageserver/ls-theia-sprotty-connector.ts
+++ b/src/sprotty/languageserver/ls-theia-sprotty-connector.ts
@@ -59,7 +59,7 @@ export class LSTheiaSprottyConnector implements TheiaSprottyConnector, TheiaSpro
     disconnect(diagramServer: TheiaDiagramServer) {
         const index = this.servers.indexOf(diagramServer);
         if (index >= 0)
-            this.servers.splice(index, 0);
+            this.servers.splice(index, 1);
         diagramServer.disconnect();
         this.diagramLanguageClient.didClose(diagramServer.clientId);
     }


### PR DESCRIPTION
When disconnecting a diagram server, it should be removed from the list of diagram servers. Also, the splice call would not make any sense when calling it with a 0 as the second parameter.

Signed-off-by: NiklasRentzCAU <nre@informatik.uni-kiel.de>