### PR TITLE
Fix yarn related warnings in CI build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,13 @@ spec:
       requests:
         memory: "2Gi"
         cpu: "1"
+    volumeMounts:
+    - mountPath: "/.yarn"
+      name: "yarn-global"
+      readonly: false
+  volumes:
+  - name: "yarn-global"
+    emptyDir: {}
 """
 
 pipeline {
@@ -25,17 +32,18 @@ pipeline {
     options {
         buildDiscarder logRotator(numToKeepStr: '15')
     }
+
+    environment {
+        YARN_CACHE_FOLDER = "${env.WORKSPACE}/yarn-cache"
+        SPAWN_WRAP_SHIM_ROOT = "${env.WORKSPACE}"
+    }
     
     stages {
         stage('Build sprotty-theia') {
-            environment {
-                SPAWN_WRAP_SHIM_ROOT = "${env.WORKSPACE}"
-                YARN_ARGS = "--cache-folder ${env.WORKSPACE}/yarn-cache --global-folder ${env.WORKSPACE}/yarn-global"
-            }
             steps {
                 container('node') {
-                    sh "yarn ${env.YARN_ARGS} install"
-                    sh "yarn ${env.YARN_ARGS} test || true" // Ignore test failures
+                    sh "yarn install"
+                    sh "yarn test || true" // Ignore test failures
                 }
             }
         }


### PR DESCRIPTION
(see also https://github.com/eclipse/sprotty/pull/155)
Fix paths for yarn "cache" and "global" directory by

Updating the kubernetes config to ensure that the default directory for yarn-global is writable
Updating the environmental variable for the cache folder path