### PR TITLE
Don't center view on resize

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,3 +9,7 @@ github:
     addComment: true
     addBadge: false
     addLabel: prebuilt-in-gitpod
+
+vscode:
+  extensions:
+    - ms-vscode.vscode-typescript-tslint-plugin@1.2.2:0nQ3PEEA0NPEt3UcbCYiIQ==

--- a/src/theia/diagram-widget.ts
+++ b/src/theia/diagram-widget.ts
@@ -16,7 +16,7 @@
 
 import {
     RequestModelAction, InitializeCanvasBoundsAction, ServerStatusAction, IActionDispatcher,
-    ModelSource, TYPES, DiagramServer, ViewerOptions
+    ModelSource, TYPES, DiagramServer, ViewerOptions, CenterAction
 } from 'sprotty';
 import { Widget } from "@phosphor/widgets";
 import { Message } from "@phosphor/messaging/lib";
@@ -136,10 +136,16 @@ export class DiagramWidget extends BaseWidget implements StatefulWidget, Navigat
             if (modelSource instanceof TheiaDiagramServer && this.connector)
                 this.connector.disconnect(modelSource);
         });
-        this.actionDispatcher.dispatch(new RequestModelAction({
+        this.requestModel();
+    }
+
+    protected async requestModel(): Promise<void> {
+        const response = await this.actionDispatcher.request(RequestModelAction.create({
             sourceUri: this.options.uri,
             diagramType: this.options.diagramType
         }));
+        await this.actionDispatcher.dispatch(response);
+        await this.actionDispatcher.dispatch(new CenterAction([], false));
     }
 
     protected getBoundsInPage(element: Element) {

--- a/src/theia/diagram-widget.ts
+++ b/src/theia/diagram-widget.ts
@@ -14,8 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { RequestModelAction, CenterAction, InitializeCanvasBoundsAction, ServerStatusAction, IActionDispatcher,
-    ModelSource, TYPES, DiagramServer, ViewerOptions } from 'sprotty';
+import {
+    RequestModelAction, InitializeCanvasBoundsAction, ServerStatusAction, IActionDispatcher,
+    ModelSource, TYPES, DiagramServer, ViewerOptions
+} from 'sprotty';
 import { Widget } from "@phosphor/widgets";
 import { Message } from "@phosphor/messaging/lib";
 import { BaseWidget } from '@theia/core/lib/browser/widgets/widget';
@@ -154,7 +156,6 @@ export class DiagramWidget extends BaseWidget implements StatefulWidget, Navigat
         super.onResize(msg);
         const newBounds = this.getBoundsInPage(this.node as Element);
         this.actionDispatcher.dispatch(new InitializeCanvasBoundsAction(newBounds));
-        this.actionDispatcher.dispatch(new CenterAction([], false));
     }
 
     protected onActivateRequest(msg: Message): void {


### PR DESCRIPTION
I think we shouldn't force the view to center itself on every resize. In cases where the view was previously zoomed-to-fit or panned to a particular element, this behavior disrupts the user's orientation, especially for large diagrams. We should leave such auto-centering or auto-zoom-to-fit behavior to clients using this library. For example, some applications might want a toggle button where you could switch auto-centering on or off.