### PR TITLE
#150 Add stage for deploying npm next artifacts to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,13 @@ pipeline {
                 }
             }
         }
+
+         stage('Deploy (master only)') {
+            when { branch 'master'}
+            steps {
+                build job: 'deploy-sprotty-theia', wait: false
+            }
+        }
     }
     
     post {


### PR DESCRIPTION
This triggers the "deploy-sprotty-theia" Jenkins job for every change on the master.
Part of eclipse/sprotty/issues/150
Note: Before merging this PR the current deployment Jobs running on the Typefox CI should be deactivated to avoid conflicts.