### PR TITLE
Switch sprotty dependency back to next

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@theia/editor": "^1.0.0",
     "@theia/filesystem": "^1.0.0",
     "@theia/monaco": "^1.0.0",
-    "sprotty": "0.9.0"
+    "sprotty": "next"
   },
   "devDependencies": {
     "@types/chai": "^4.2.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1969,7 +1969,7 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-inversify@5.0.1, inversify@^5.0.1:
+inversify@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/inversify/-/inversify-5.0.1.tgz#500d709b1434896ce5a0d58915c4a4210e34fb6e"
   integrity sha512-Ieh06s48WnEYGcqHepdsJUIJUXpwH5o5vodAX+DK2JA/gjy4EbEcQZxw+uFfzysmKjiLXGYwNG3qDZsKVMcINQ==
@@ -3572,14 +3572,14 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sprotty@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.9.0.tgz#5644cdb239c43e878705fe76d71ffc73f27cd27b"
-  integrity sha512-kPcXVgspNnMq/ysFFOVfjBkrNK/w9LXSiX1mx3mkEiEVbthjEiKicw+l9uwW9RJH+QvqrK8LrXqEZzKGERUQyA==
+sprotty@next:
+  version "0.10.0-next.20e60ad"
+  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.10.0-next.20e60ad.tgz#fbc9943f87be06d2ed7a5409c2cef090f7888e47"
+  integrity sha512-wzuLRE3vvxYTeNdDWVVnNLkwoWMYQRqWc398/no9JJg4UGIAYA5YBlxpHRb7B5aOaBodXGM0ufl7ETjgwTktcQ==
   dependencies:
     autocompleter "5.1.0"
     file-saver "2.0.2"
-    inversify "5.0.1"
+    inversify "^5.0.1"
     snabbdom "0.7.3"
     snabbdom-jsx "0.4.2"
     snabbdom-virtualize "0.7.0"


### PR DESCRIPTION
After the last release the dependency to "sprotty" was not set back to "next. As discussed [here](https://github.com/eclipse/sprotty-theia/issues/58) we should always do that so that unreleased sprotty changes can be tested.